### PR TITLE
Fix aisle ordering persistence bug

### DIFF
--- a/CATEGORY_ORDER_FIX.md
+++ b/CATEGORY_ORDER_FIX.md
@@ -1,0 +1,80 @@
+# Category Order Persistence Fix
+
+## Problem
+The aisle/category ordering when using drag and drop didn't persist after:
+1. Page refresh
+2. Undoing a delete on an item
+
+## Root Cause
+The `orderedCategories` state was only stored in React component state and was reset every time `loadData()` was called (which happens on page refresh and after undo operations).
+
+## Solution
+Implemented persistent storage for category order by:
+
+### 1. Database Schema Changes
+- Added `category_order` JSONB column to `shopping_lists` table
+- Created migration script: `sql/add_category_order_column.sql`
+
+### 2. Backend Changes
+- Added `updateCategoryOrder()` function in `src/lib/supabase/client.ts`
+- Updated TypeScript types in `src/lib/supabase/types.ts` to include `category_order` field
+
+### 3. Frontend Changes
+- Modified `loadData()` function to load saved category order from database
+- Updated `onDragEnd()` function to persist category order changes
+- Enhanced `useEffect` for category changes to persist when new categories are added
+- Added fallback logic to handle cases where no saved order exists
+
+## Key Implementation Details
+
+### Loading Category Order
+```typescript
+// Load category order from the list, or create default order from items
+const savedCategoryOrder = listData.category_order as string[] | null
+const availableCategories = Array.from(new Set(itemsData.map(item => item.category || 'Other')))
+
+if (savedCategoryOrder && savedCategoryOrder.length > 0) {
+  // Use saved order, but add any new categories that aren't in the saved order
+  const newCategories = availableCategories.filter(cat => !savedCategoryOrder.includes(cat))
+  const finalOrder = [...savedCategoryOrder, ...newCategories]
+  setOrderedCategories(finalOrder)
+} else {
+  // No saved order, use default order from items
+  setOrderedCategories(availableCategories)
+}
+```
+
+### Persisting Category Order
+```typescript
+const onDragEnd = async (result: any) => {
+  // ... reorder logic ...
+  
+  // Persist the new category order to the database
+  if (!isDemoMode) {
+    try {
+      await updateCategoryOrder(listId, newOrderedCategories)
+    } catch (error) {
+      console.error('Failed to save category order:', error)
+    }
+  }
+}
+```
+
+## Benefits
+1. **Persistence**: Category order now survives page refreshes
+2. **Undo Compatibility**: Order is maintained when undoing item deletions
+3. **Backward Compatibility**: Existing lists without saved order work normally
+4. **New Category Handling**: New categories are automatically added to the end of the order
+5. **Error Handling**: Graceful degradation if database operations fail
+
+## Testing
+- Created and ran test script to verify the logic works correctly
+- Test covers drag-and-drop reordering, page refresh simulation, and new category addition
+
+## Migration
+Run the migration script on existing databases:
+```sql
+-- Execute sql/add_category_order_column.sql
+```
+
+This will add the `category_order` column to existing `shopping_lists` tables without affecting existing data.

--- a/sql/01_create_tables.sql
+++ b/sql/01_create_tables.sql
@@ -25,6 +25,7 @@ CREATE TABLE shopping_lists (
   name TEXT NOT NULL,
   description TEXT,
   is_archived BOOLEAN DEFAULT FALSE,
+  category_order JSONB DEFAULT '[]'::jsonb, -- Store ordered array of category names
   created_at TIMESTAMP WITH TIME ZONE DEFAULT TIMEZONE('utc'::text, NOW()) NOT NULL,
   updated_at TIMESTAMP WITH TIME ZONE DEFAULT TIMEZONE('utc'::text, NOW()) NOT NULL
 );

--- a/sql/add_category_order_column.sql
+++ b/sql/add_category_order_column.sql
@@ -1,0 +1,25 @@
+-- Migration to add category_order column to shopping_lists table
+-- This script should be run on existing databases to add the new column
+
+-- Add the category_order column if it doesn't exist
+DO $$ 
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 
+        FROM information_schema.columns 
+        WHERE table_name = 'shopping_lists' 
+        AND column_name = 'category_order'
+    ) THEN
+        ALTER TABLE shopping_lists 
+        ADD COLUMN category_order JSONB DEFAULT '[]'::jsonb;
+        
+        -- Add a comment to document the column
+        COMMENT ON COLUMN shopping_lists.category_order IS 'Stores ordered array of category names for custom aisle ordering';
+    END IF;
+END $$;
+
+-- Verify the column was added
+SELECT column_name, data_type, is_nullable, column_default
+FROM information_schema.columns 
+WHERE table_name = 'shopping_lists' 
+AND column_name = 'category_order';

--- a/src/lib/supabase/client.ts
+++ b/src/lib/supabase/client.ts
@@ -144,6 +144,19 @@ export async function updateShoppingList(listId: string, updates: Partial<Shoppi
   return { data, error }
 }
 
+export async function updateCategoryOrder(listId: string, categoryOrder: string[]) {
+  if (!supabase) return { data: null, error: 'Supabase not available' }
+
+  const { data, error } = await supabase
+    .from('shopping_lists')
+    .update({ category_order: categoryOrder })
+    .eq('id', listId)
+    .select()
+    .single()
+
+  return { data, error }
+}
+
 export async function deleteShoppingList(listId: string) {
   if (!supabase) return { error: 'Supabase not available' }
 

--- a/src/lib/supabase/types.ts
+++ b/src/lib/supabase/types.ts
@@ -45,6 +45,7 @@ export type Database = {
           name: string
           description: string | null
           is_archived: boolean
+          category_order: Json | null
           is_shared: boolean | null
           share_code: string | null
           created_by: string | null
@@ -57,6 +58,7 @@ export type Database = {
           name: string
           description?: string | null
           is_archived?: boolean
+          category_order?: Json | null
           is_shared?: boolean | null
           share_code?: string | null
           created_by?: string | null
@@ -69,6 +71,7 @@ export type Database = {
           name?: string
           description?: string | null
           is_archived?: boolean
+          category_order?: Json | null
           is_shared?: boolean | null
           share_code?: string | null
           created_by?: string | null


### PR DESCRIPTION
Persist drag-and-drop aisle ordering across sessions and undo operations.

Previously, aisle order was only stored in local component state, causing it to reset on page refresh or when `loadData()` was called (e.g., after an undo operation).

---

[Open in Web](https://cursor.com/agents?id=bc-48fc44d8-c81c-409e-aae4-f4d84838c303) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-48fc44d8-c81c-409e-aae4-f4d84838c303) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)