### PR TITLE
Improve sync toaster behavior and auto-dismiss

### DIFF
--- a/src/components/OfflineIndicator.tsx
+++ b/src/components/OfflineIndicator.tsx
@@ -286,7 +286,7 @@ export function SyncNotification() {
   const isClient = useIsClient()
   const [showNotification, setShowNotification] = useState(false)
   const [notificationType, setNotificationType] = useState<'success' | 'error' | null>(null)
-  const { syncing, lastSync, errors } = useSyncStatus()
+  const { syncing, lastSync, lastSyncCount, errors } = useSyncStatus()
   const lastSyncRef = useRef<string | null>(null)
 
   useEffect(() => {
@@ -303,14 +303,15 @@ export function SyncNotification() {
     if (!isClient) return
     
     // Only show success notification when lastSync actually changes (new sync completes)
-    if (lastSync && lastSync !== lastSyncRef.current && !syncing && !showNotification) {
+    // AND when there were actual items synced (lastSyncCount > 0)
+    if (lastSync && lastSync !== lastSyncRef.current && !syncing && !showNotification && lastSyncCount > 0) {
       lastSyncRef.current = lastSync
       setNotificationType('success')
       setShowNotification(true)
-      const timer = setTimeout(() => setShowNotification(false), 3000)
+      const timer = setTimeout(() => setShowNotification(false), 6000)
       return () => clearTimeout(timer)
     }
-  }, [lastSync, syncing, showNotification, isClient])
+  }, [lastSync, lastSyncCount, syncing, showNotification, isClient])
 
   if (!isClient || !showNotification) return null
 
@@ -329,7 +330,7 @@ export function SyncNotification() {
             {isError ? 'Sync Error' : 'Sync Complete'}
           </div>
           <div className="text-xs text-gray-300">
-            {isError ? errors[0] : 'All changes synced successfully'}
+            {isError ? errors[0] : `${lastSyncCount} item${lastSyncCount !== 1 ? 's' : ''} synced successfully`}
           </div>
         </div>
         <button

--- a/src/lib/offline/sync.ts
+++ b/src/lib/offline/sync.ts
@@ -27,7 +27,8 @@ class SyncManager {
     lastSync: null,
     pendingChanges: 0,
     syncing: false,
-    errors: []
+    errors: [],
+    lastSyncCount: 0
   }
 
   constructor() {
@@ -160,7 +161,8 @@ class SyncManager {
       this.updateSyncStatus({
         syncing: false,
         lastSync: new Date().toISOString(),
-        pendingChanges: await this.getPendingChangesCount()
+        pendingChanges: await this.getPendingChangesCount(),
+        lastSyncCount: result.synced
       })
 
       return result
@@ -504,6 +506,7 @@ export interface SyncStatus {
   pendingChanges: number
   syncing: boolean
   errors: string[]
+  lastSyncCount: number
 }
 
 // Export singleton instance


### PR DESCRIPTION
Enhance sync complete toaster to only appear when items are synced, auto-dismiss after 6 seconds, and show the synced item count.

---

[Open in Web](https://cursor.com/agents?id=bc-537455f6-07bd-4fa4-afc0-8e9ec3e28b6b) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-537455f6-07bd-4fa4-afc0-8e9ec3e28b6b) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)