### PR TITLE
Fix recent lists item count bug

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -854,7 +854,7 @@ export default function DashboardPage() {
                       <div className="flex-1 min-w-0">
                         <p className="font-medium text-glass-heading truncate">{list.name}</p>
                         <p className="text-xs text-glass-muted">
-                          {isDemoMode && isMockList(list) ? list.itemCount : 0} items • {formatDate(list.created_at)}
+                          {list.itemCount} items • {formatDate(list.created_at)}
                         </p>
                       </div>
                       {list.is_shared && (
@@ -1132,7 +1132,7 @@ export default function DashboardPage() {
                   <h4 className="font-medium text-glass-heading">{list.name}</h4>
                   <p className="text-sm text-glass-muted">{list.description}</p>
                   <p className="text-xs text-glass-muted mt-1">
-                    {isDemoMode && isMockList(list) ? list.itemCount : 0} items
+                    {list.itemCount} items
                   </p>
                 </Link>
               ))}


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Display the actual item count for all lists instead of conditionally showing 0.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The previous display logic incorrectly showed 0 items for real lists (non-demo mode), even though the `itemCount` was correctly calculated. This PR ensures the correct `itemCount` is always displayed in both the recent lists section and the search modal.

---

[Open in Web](https://cursor.com/agents?id=bc-780972c9-d846-4565-b4ae-f520d5ea803b) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-780972c9-d846-4565-b4ae-f520d5ea803b) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)