### PR TITLE
Add new categories with lucide-react icons

### DIFF
--- a/src/app/list/[listId]/page.tsx
+++ b/src/app/list/[listId]/page.tsx
@@ -42,7 +42,12 @@ import {
   MicOff,
   Play,
   Square,
-  Type
+  Type,
+  Leaf,
+  Receipt,
+  PackageCheck,
+  Trash,
+  ThermometerSnowflake
 } from 'lucide-react'
 
 import { DragDropContext, Droppable, Draggable } from '@hello-pangea/dnd'
@@ -76,7 +81,12 @@ const categoryIcons: { [key: string]: any } = {
   'Other': Package2,
   'Snacks': Cookie,
   'Beverages': Milk,
-  'Party': Sparkles
+  'Party': Sparkles,
+  'Organics': Leaf,
+  'Registers': Receipt,
+  'Canned Goods': PackageCheck,
+  'Disposable': Trash,
+  'Freezer': ThermometerSnowflake
 }
 
 // Mock data for demo mode

--- a/src/app/list/[listId]/page.tsx
+++ b/src/app/list/[listId]/page.tsx
@@ -1801,6 +1801,11 @@ export default function ListPage() {
                     <option value="Household">Household</option>
                     <option value="Snacks">Snacks</option>
                     <option value="Beverages">Beverages</option>
+                    <option value="Organics">Organics</option>
+                    <option value="Registers">Registers</option>
+                    <option value="Canned Goods">Canned Goods</option>
+                    <option value="Disposable">Disposable</option>
+                    <option value="Freezer">Freezer</option>
                     <option value="Other">Other</option>
                   </select>
                 </div>
@@ -2282,6 +2287,13 @@ export default function ListPage() {
                     <option value="Pantry">Pantry</option>
                     <option value="Frozen">Frozen</option>
                     <option value="Household">Household</option>
+                    <option value="Snacks">Snacks</option>
+                    <option value="Beverages">Beverages</option>
+                    <option value="Organics">Organics</option>
+                    <option value="Registers">Registers</option>
+                    <option value="Canned Goods">Canned Goods</option>
+                    <option value="Disposable">Disposable</option>
+                    <option value="Freezer">Freezer</option>
                     <option value="Other">Other</option>
                   </select>
                 </div>

--- a/src/lib/ai/gemini.ts
+++ b/src/lib/ai/gemini.ts
@@ -22,7 +22,8 @@ const VALID_UNITS: UnitType[] = [
 
 const COMMON_CATEGORIES = [
   'Produce', 'Dairy', 'Meat & Seafood', 'Bakery', 'Pantry', 'Frozen', 
-  'Beverages', 'Snacks', 'Health & Beauty', 'Household', 'Baby', 'Pet', 'General'
+  'Beverages', 'Snacks', 'Health & Beauty', 'Household', 'Baby', 'Pet', 'General',
+  'Organics', 'Registers', 'Canned Goods', 'Disposable', 'Freezer'
 ]
 
 export async function parseShoppingListWithAI(

--- a/src/lib/ai/suggestions.ts
+++ b/src/lib/ai/suggestions.ts
@@ -20,7 +20,8 @@ export interface SuggestionsResponse {
 
 const COMMON_CATEGORIES = [
   'Produce', 'Dairy', 'Meat & Seafood', 'Bakery', 'Pantry', 'Frozen', 
-  'Beverages', 'Snacks', 'Health & Beauty', 'Household', 'Baby', 'Pet', 'General'
+  'Beverages', 'Snacks', 'Health & Beauty', 'Household', 'Baby', 'Pet', 'General',
+  'Organics', 'Registers', 'Canned Goods', 'Disposable', 'Freezer'
 ]
 
 const VALID_UNITS: UnitType[] = [


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Add new categories (Organics, Registers, Canned Goods, Disposable, Freezer, Pantry) and their Lucide React icons to the application.

---

[Open in Web](https://cursor.com/agents?id=bc-468c8b8f-9a02-4e03-b296-dc03c7bb1360) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-468c8b8f-9a02-4e03-b296-dc03c7bb1360) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)