### PR TITLE
Update app colors for glassmorphism

### DIFF
--- a/src/app/animations.css
+++ b/src/app/animations.css
@@ -13,8 +13,8 @@
 }
 
 @keyframes pulse-glow {
-  0%, 100% { box-shadow: 0 0 20px rgba(147, 51, 234, 0.3), 0 8px 32px rgba(31, 38, 135, 0.37); }
-  50% { box-shadow: 0 0 40px rgba(147, 51, 234, 0.5), 0 15px 50px rgba(31, 38, 135, 0.4); }
+  0%, 100% { box-shadow: 0 0 20px rgba(99, 102, 241, 0.3), 0 8px 32px rgba(31, 38, 135, 0.37); }
+  50% { box-shadow: 0 0 40px rgba(99, 102, 241, 0.5), 0 15px 50px rgba(31, 38, 135, 0.4); }
 }
 
 @keyframes slide-up-fade {
@@ -199,7 +199,7 @@
   width: 0;
   height: 0;
   border-radius: 50%;
-  background: radial-gradient(circle, rgba(147, 51, 234, 0.3) 0%, transparent 70%);
+  background: radial-gradient(circle, rgba(99, 102, 241, 0.3) 0%, transparent 70%);
   transform: translate(-50%, -50%);
   transition: width 0.5s ease, height 0.5s ease;
 }
@@ -243,7 +243,7 @@
 .custom-scrollbar::-webkit-scrollbar-thumb {
   background: linear-gradient(
     180deg,
-    rgba(147, 51, 234, 0.5) 0%,
+    rgba(99, 102, 241, 0.5) 0%,
     rgba(99, 102, 241, 0.5) 100%
   );
   border-radius: 5px;
@@ -253,7 +253,7 @@
 .custom-scrollbar::-webkit-scrollbar-thumb:hover {
   background: linear-gradient(
     180deg,
-    rgba(147, 51, 234, 0.7) 0%,
+    rgba(99, 102, 241, 0.7) 0%,
     rgba(99, 102, 241, 0.7) 100%
   );
 }
@@ -284,7 +284,7 @@
   position: absolute;
   inset: -4px;
   border-radius: inherit;
-  border: 2px solid rgba(147, 51, 234, 0.5);
+  border: 2px solid rgba(99, 102, 241, 0.5);
   animation: pulse-glow 2s ease-in-out infinite;
 }
 
@@ -363,10 +363,10 @@
 /* Glow Pulse for Important Elements */
 @keyframes glow-pulse {
   0%, 100% {
-    filter: brightness(1) drop-shadow(0 0 10px rgba(147, 51, 234, 0.5));
+    filter: brightness(1) drop-shadow(0 0 10px rgba(99, 102, 241, 0.5));
   }
   50% {
-    filter: brightness(1.2) drop-shadow(0 0 20px rgba(147, 51, 234, 0.8));
+    filter: brightness(1.2) drop-shadow(0 0 20px rgba(99, 102, 241, 0.8));
   }
 }
 
@@ -389,10 +389,10 @@ select:focus {
 
 @keyframes focus-glow {
   0% {
-    box-shadow: 0 0 0 0 rgba(147, 51, 234, 0);
+    box-shadow: 0 0 0 0 rgba(99, 102, 241, 0);
   }
   100% {
-    box-shadow: 0 0 0 4px rgba(147, 51, 234, 0.2);
+    box-shadow: 0 0 0 4px rgba(99, 102, 241, 0.2);
   }
 }
 

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -11,10 +11,10 @@
   --color-glass-dark-border: rgb(255 255 255 / 0.2);
   
   /* Primary brand colors */
-  --color-primary: oklch(0.69 0.25 262.83);
-  --color-primary-light: oklch(0.79 0.20 262.83);
-  --color-secondary: oklch(0.71 0.25 328.36);
-  --color-accent: oklch(0.75 0.25 180.00);
+  --color-primary: #6366F1;
+  --color-primary-light: #A5B4FC;
+  --color-secondary: #06B6D4;
+  --color-accent: #06B6D4;
   
   /* Text colors - High contrast for glassmorphism */
   --color-text-primary: oklch(0.10 0.05 285.83);
@@ -140,11 +140,8 @@
 :root {
   --background: linear-gradient(
     135deg,
-    oklch(0.85 0.15 300.00) 0%,
-    oklch(0.80 0.20 240.00) 25%,
-    oklch(0.75 0.25 180.00) 50%,
-    oklch(0.70 0.20 120.00) 75%,
-    oklch(0.75 0.15 60.00) 100%
+    #6366F1 0%,
+    #06B6D4 100%
   );
   --foreground: var(--color-text-on-glass);
   --blur-amount: 10px;
@@ -154,11 +151,8 @@
 .light {
   --background: linear-gradient(
     135deg,
-    oklch(0.85 0.15 300.00) 0%,
-    oklch(0.80 0.20 240.00) 25%,
-    oklch(0.75 0.25 180.00) 50%,
-    oklch(0.70 0.20 120.00) 75%,
-    oklch(0.75 0.15 60.00) 100%
+    #6366F1 0%,
+    #06B6D4 100%
   );
   --foreground: var(--color-text-on-glass);
 }
@@ -167,11 +161,8 @@
 .dark {
   --background: linear-gradient(
     135deg,
-    oklch(0.25 0.15 300.00) 0%,
-    oklch(0.20 0.20 240.00) 25%,
-    oklch(0.15 0.25 180.00) 50%,
-    oklch(0.20 0.20 120.00) 75%,
-    oklch(0.25 0.15 60.00) 100%
+    #312E81 0%,
+    #164E63 100%
   );
   --foreground: var(--color-text-light);
 }
@@ -223,7 +214,7 @@ body::before {
   background: linear-gradient(
     45deg,
     transparent 30%,
-    rgba(147, 51, 234, 0.05) 50%,
+    rgba(99, 102, 241, 0.05) 50%,
     transparent 70%
   );
   animation: gradient-shift 20s ease infinite;


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Update the app's color scheme to a two-shade indigo-cyan palette for improved visual cohesion and glassmorphism compatibility in light/dark modes.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->

---

[Open in Web](https://cursor.com/agents?id=bc-e5a34df4-d87c-4e19-87a2-7b315f161eb4) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-e5a34df4-d87c-4e19-87a2-7b315f161eb4) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)