### PR TITLE
Update amount field to number input with steppers

### DIFF
--- a/src/app/list/[listId]/page.tsx
+++ b/src/app/list/[listId]/page.tsx
@@ -1827,8 +1827,8 @@ export default function ListPage() {
                     <label className="block text-sm font-medium text-glass-muted mb-2">Amount</label>
                     <input
                       type="number"
-                      min="0.1"
-                      step="0.1"
+                      min="1"
+                      step="1"
                       value={editItemForm.amount}
                       onChange={(e) => setEditItemForm({ ...editItemForm, amount: parseFloat(e.target.value) || 1 })}
                       className="w-full glass-premium border-0 rounded-lg px-4 py-3 text-glass focus-ring transition-all duration-300 hover:shadow-lg"
@@ -2314,8 +2314,8 @@ export default function ListPage() {
                     <label className="block text-sm font-medium text-glass-muted mb-2">Amount</label>
                     <input
                       type="number"
-                      min="0.1"
-                      step="0.1"
+                      min="1"
+                      step="1"
                       placeholder="1"
                       value={newItem.amount}
                       onChange={(e) => setNewItem({ ...newItem, amount: parseFloat(e.target.value) || 1 })}


### PR DESCRIPTION
Update amount input fields to use `type='number'` with `step='1'` and `min='1'` to enable whole number increments.

---
<a href="https://cursor.com/background-agent?bcId=bc-96f9a9cc-100d-456e-a7c3-ca69f87ebafb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-96f9a9cc-100d-456e-a7c3-ca69f87ebafb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>