### PR TITLE
Fix navbar z-index for modal forms

### DIFF
--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -31,7 +31,7 @@ export default function Navbar() {
   ]
 
   return (
-    <header className="sticky top-0 z-50 p-4 animate-slide-down">
+    <header className="sticky top-0 z-10 p-4 animate-slide-down">
       <div className="glass-premium flex items-center justify-between p-2 px-4 rounded-full hover-lift animate-scale-in">
         {/* Logo */}
         <div className="flex items-center gap-3">
@@ -169,7 +169,7 @@ function SyncPopover() {
         )}
       </button>
       {open && (
-        <div className="absolute left-0 mt-2 min-w-[260px] max-w-xs bg-black/80 border border-white/30 rounded-lg shadow-xl backdrop-blur-md z-50 p-4">
+        <div className="absolute left-0 mt-2 min-w-[260px] max-w-xs bg-black/80 border border-white/30 rounded-lg shadow-xl backdrop-blur-md z-20 p-4">
           <div className="flex items-center justify-between mb-2">
             <span className="text-sm font-medium text-white">Sync Status</span>
             <button onClick={() => setOpen(false)} className="text-gray-300 hover:text-white" aria-label="Close sync status">


### PR DESCRIPTION
Reduce navbar and sync popover z-index to fix overlapping with edit/add item forms.

Previously, the navbar's `z-50` caused it to appear above modals (which use `z-[9999]`), likely due to stacking context issues. By lowering the navbar's z-index to `z-10` and its popover's to `z-20`, modals now correctly appear on top.

---
<a href="https://cursor.com/background-agent?bcId=bc-b33ec863-d7e7-4957-bcbb-1f4b0979b957">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b33ec863-d7e7-4957-bcbb-1f4b0979b957">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>