### PR TITLE
Fix mobile filter pill drag visual bug

### DIFF
--- a/src/app/list/[listId]/page.tsx
+++ b/src/app/list/[listId]/page.tsx
@@ -1522,6 +1522,11 @@ export default function ListPage() {
                               <div
                                 ref={provided.innerRef}
                                 {...provided.draggableProps}
+                                style={{
+                                  ...provided.draggableProps.style,
+                                  zIndex: snapshot.isDragging ? 1000 : 'auto',
+                                  position: snapshot.isDragging ? 'relative' : undefined,
+                                }}
                                 onClick={() => setCategoryFilter(category)}
                                 className={`px-2.5 py-1.5 rounded-full text-xs font-medium transition-all flex items-center gap-1.5 whitespace-nowrap cursor-pointer ${
                                   (categoryFilter === category || snapshot.isDragging)


### PR DESCRIPTION
Elevate the z-index and position of draggable filter pills to prevent them from dropping behind other elements on mobile.

---
<a href="https://cursor.com/background-agent?bcId=bc-c2aef7a7-c9ca-483c-84ee-6bc312fc56d8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c2aef7a7-c9ca-483c-84ee-6bc312fc56d8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>