### PR TITLE
Fix navbar z-index for forms

### DIFF
--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -31,7 +31,7 @@ export default function Navbar() {
   ]
 
   return (
-    <header className="sticky top-0 z-10 p-4 animate-slide-down">
+    <header className="sticky top-0 z-40 p-4 animate-slide-down">
       <div className="glass-premium flex items-center justify-between p-2 px-4 rounded-full hover-lift animate-scale-in">
         {/* Logo */}
         <div className="flex items-center gap-3">


### PR DESCRIPTION
Update navbar z-index to ensure it appears above regular content but remains behind forms and modals.

---
<a href="https://cursor.com/background-agent?bcId=bc-824f2e51-8836-4a8a-95cb-f58acf0e4069">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-824f2e51-8836-4a8a-95cb-f58acf0e4069">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>