### PR TITLE
Fix recently viewed list and dashboard order

### DIFF
--- a/RECENTLY_VIEWED_FIX.md
+++ b/RECENTLY_VIEWED_FIX.md
@@ -1,0 +1,45 @@
+# Recently Viewed Lists Bug Fix
+
+## Problem
+The recently viewed list mechanism wasn't working properly. Lists weren't appearing in the correct order in the dashboard, with the most recently used lists not appearing first.
+
+## Root Causes
+1. **Missing sorting in offline mode**: When lists were fetched from IndexedDB (offline storage), they weren't sorted by `updated_at`.
+2. **Missing sorting in dashboard**: The dashboard component wasn't sorting lists after fetching them.
+3. **List timestamp not updated on item changes**: The shopping list's `updated_at` timestamp was only updated when the list itself was modified (name, description, etc.), but not when items were added, updated, or deleted.
+
+## Solution
+
+### 1. Added Sorting in Dashboard (`src/app/dashboard/page.tsx`)
+- Modified `fetchShoppingLists` to sort lists by `updated_at` in descending order after fetching
+- Ensures the most recently used lists appear first in the UI
+
+### 2. Added Sorting in Offline Client (`src/lib/offline/client.ts`)
+- Modified `getShoppingLists` to sort lists by `updated_at` when fetching from IndexedDB
+- Ensures consistent behavior between online and offline modes
+
+### 3. Update List Timestamp on Item Changes
+- Created database trigger (`sql/fix_recently_viewed_trigger.sql`) that automatically updates the shopping list's `updated_at` when items are modified
+- Modified offline client methods to update list timestamps:
+  - `createItem`: Updates parent list's `updated_at` when item is created
+  - `updateItem`: Updates parent list's `updated_at` when item is modified
+  - `deleteItem`: Updates parent list's `updated_at` when item is deleted
+
+## Database Migration Required
+Run the following SQL to add the trigger:
+```sql
+-- Execute the contents of sql/fix_recently_viewed_trigger.sql
+```
+
+## Testing
+1. Create a new shopping list
+2. Add items to different lists
+3. Check that the list you just modified appears first in the "Recent Lists" section
+4. Update items in an older list
+5. Verify that list now appears at the top
+6. Test both online and offline modes
+
+## Impact
+- Lists will now properly reflect their actual usage patterns
+- The "Recent Lists" section will show genuinely recently used lists
+- Better user experience as frequently used lists are easily accessible

--- a/RECENTLY_VIEWED_FIX.md
+++ b/RECENTLY_VIEWED_FIX.md
@@ -7,11 +7,13 @@ The recently viewed list mechanism wasn't working properly. Lists weren't appear
 1. **Missing sorting in offline mode**: When lists were fetched from IndexedDB (offline storage), they weren't sorted by `updated_at`.
 2. **Missing sorting in dashboard**: The dashboard component wasn't sorting lists after fetching them.
 3. **List timestamp not updated on item changes**: The shopping list's `updated_at` timestamp was only updated when the list itself was modified (name, description, etc.), but not when items were added, updated, or deleted.
+4. **Dashboard not refreshing on navigation**: When navigating back to the dashboard from a list page, the lists weren't being refreshed, showing stale data.
 
 ## Solution
 
 ### 1. Added Sorting in Dashboard (`src/app/dashboard/page.tsx`)
 - Modified `fetchShoppingLists` to sort lists by `updated_at` in descending order after fetching
+- Added debug logging to track sorting behavior
 - Ensures the most recently used lists appear first in the UI
 
 ### 2. Added Sorting in Offline Client (`src/lib/offline/client.ts`)
@@ -24,12 +26,48 @@ The recently viewed list mechanism wasn't working properly. Lists weren't appear
   - `createItem`: Updates parent list's `updated_at` when item is created
   - `updateItem`: Updates parent list's `updated_at` when item is modified
   - `deleteItem`: Updates parent list's `updated_at` when item is deleted
+- Added debug logging to track timestamp updates
+
+### 4. Dashboard Auto-Refresh
+- Added event listeners for `focus` and `visibilitychange` events
+- Dashboard now refreshes shopping lists when:
+  - User navigates back to the dashboard
+  - Browser tab regains focus
+  - Page becomes visible after being hidden
 
 ## Database Migration Required
 Run the following SQL to add the trigger:
 ```sql
 -- Execute the contents of sql/fix_recently_viewed_trigger.sql
 ```
+
+## Debugging Steps
+
+### 1. Verify Trigger Exists
+Run this SQL in Supabase SQL editor:
+```sql
+SELECT EXISTS (
+    SELECT 1 
+    FROM pg_trigger 
+    WHERE tgname = 'update_list_timestamp_on_item_change'
+) as trigger_exists;
+```
+
+### 2. Check Console Logs
+Open browser developer console and look for:
+- "Dashboard: Lists before sorting" - shows the order lists are fetched
+- "Dashboard: Lists after sorting" - shows the order after sorting
+- "Dashboard: Page gained focus, refreshing lists..." - confirms refresh on navigation
+- "OfflineClient: Updating list timestamp..." - confirms timestamp updates
+
+### 3. Manual Test
+1. Note which list is currently at the top
+2. Go to an older list and add/modify an item
+3. Navigate back to dashboard
+4. The modified list should now appear at the top
+
+### 4. Check Database Directly
+Run `test_trigger_simple.sql` to manually verify the trigger is working.
 
 ## Testing
 1. Create a new shopping list
@@ -38,8 +76,10 @@ Run the following SQL to add the trigger:
 4. Update items in an older list
 5. Verify that list now appears at the top
 6. Test both online and offline modes
+7. Navigate away and back to dashboard - lists should refresh
 
 ## Impact
 - Lists will now properly reflect their actual usage patterns
 - The "Recent Lists" section will show genuinely recently used lists
 - Better user experience as frequently used lists are easily accessible
+- Dashboard stays up-to-date when navigating between pages

--- a/RECENTLY_VIEWED_FIX.md
+++ b/RECENTLY_VIEWED_FIX.md
@@ -21,7 +21,18 @@ The recently viewed list mechanism wasn't working properly. Lists weren't appear
 - Ensures consistent behavior between online and offline modes
 
 ### 3. Update List Timestamp on Item Changes
+We implemented two approaches:
+
+#### Option A: Database Trigger (Preferred but may not work in all Supabase environments)
 - Created database trigger (`sql/fix_recently_viewed_trigger.sql`) that automatically updates the shopping list's `updated_at` when items are modified
+- Run `create_trigger_final.sql` to create the trigger
+
+#### Option B: Application-Level Updates (Fallback solution)
+- Added `updateListTimestamp` helper function in `src/lib/supabase/client.ts`
+- Modified Supabase client functions to update list timestamps:
+  - `createItemOriginal`: Updates list timestamp after creating item
+  - `updateItemOriginal`: Updates list timestamp after updating item
+  - `deleteItemOriginal`: Updates list timestamp after deleting item
 - Modified offline client methods to update list timestamps:
   - `createItem`: Updates parent list's `updated_at` when item is created
   - `updateItem`: Updates parent list's `updated_at` when item is modified
@@ -35,11 +46,13 @@ The recently viewed list mechanism wasn't working properly. Lists weren't appear
   - Browser tab regains focus
   - Page becomes visible after being hidden
 
-## Database Migration Required
+## Database Migration (Try First)
 Run the following SQL to add the trigger:
 ```sql
--- Execute the contents of sql/fix_recently_viewed_trigger.sql
+-- Execute the contents of create_trigger_final.sql
 ```
+
+If the trigger doesn't work (check with `verify_trigger_setup.sql`), the application-level solution will handle it automatically.
 
 ## Debugging Steps
 
@@ -67,7 +80,7 @@ Open browser developer console and look for:
 4. The modified list should now appear at the top
 
 ### 4. Check Database Directly
-Run `test_trigger_simple.sql` to manually verify the trigger is working.
+Run `test_without_auth.sql` with your user ID to manually verify the behavior.
 
 ## Testing
 1. Create a new shopping list
@@ -83,3 +96,4 @@ Run `test_trigger_simple.sql` to manually verify the trigger is working.
 - The "Recent Lists" section will show genuinely recently used lists
 - Better user experience as frequently used lists are easily accessible
 - Dashboard stays up-to-date when navigating between pages
+- Works regardless of database trigger support

--- a/check_permissions.sql
+++ b/check_permissions.sql
@@ -1,0 +1,55 @@
+-- Check current user and permissions
+SELECT current_user, session_user;
+
+-- Check if we have permission to create triggers
+SELECT has_database_privilege(current_user, current_database(), 'CREATE');
+
+-- Check if there are any security policies that might block the trigger
+SELECT 
+    schemaname,
+    tablename,
+    policyname,
+    permissive,
+    roles,
+    cmd,
+    qual,
+    with_check
+FROM pg_policies
+WHERE tablename IN ('shopping_lists', 'items')
+ORDER BY tablename, policyname;
+
+-- Check table ownership
+SELECT 
+    n.nspname as schema_name,
+    c.relname as table_name,
+    pg_get_userbyid(c.relowner) as owner,
+    has_table_privilege(current_user, c.oid, 'TRIGGER') as can_create_trigger
+FROM pg_class c
+JOIN pg_namespace n ON n.oid = c.relnamespace
+WHERE c.relname IN ('shopping_lists', 'items')
+AND n.nspname = 'public';
+
+-- Alternative approach: Update shopping list directly when modifying items
+-- This can be used if triggers don't work
+/*
+-- When creating an item:
+WITH new_item AS (
+  INSERT INTO items (list_id, name, amount, unit, category)
+  VALUES ('your-list-id', 'New Item', 1, 'pcs', 'Other')
+  RETURNING list_id
+)
+UPDATE shopping_lists 
+SET updated_at = NOW() 
+WHERE id = (SELECT list_id FROM new_item);
+
+-- When updating an item:
+WITH updated_item AS (
+  UPDATE items 
+  SET name = 'Updated Name'
+  WHERE id = 'item-id'
+  RETURNING list_id
+)
+UPDATE shopping_lists 
+SET updated_at = NOW() 
+WHERE id = (SELECT list_id FROM updated_item);
+*/

--- a/check_rls_policies.sql
+++ b/check_rls_policies.sql
@@ -1,0 +1,48 @@
+-- Check if RLS is enabled on tables
+SELECT 
+    schemaname,
+    tablename,
+    rowsecurity
+FROM pg_tables
+WHERE tablename IN ('shopping_lists', 'items')
+AND schemaname = 'public';
+
+-- Check RLS policies on shopping_lists
+SELECT 
+    pol.polname as policy_name,
+    pol.polcmd as command,
+    pol.polroles::regrole[] as roles,
+    pg_get_expr(pol.polqual, pol.polrelid) as using_expression,
+    pg_get_expr(pol.polwithcheck, pol.polrelid) as with_check_expression
+FROM pg_policy pol
+JOIN pg_class pc ON pol.polrelid = pc.oid
+WHERE pc.relname = 'shopping_lists';
+
+-- Check RLS policies on items
+SELECT 
+    pol.polname as policy_name,
+    pol.polcmd as command,
+    pol.polroles::regrole[] as roles,
+    pg_get_expr(pol.polqual, pol.polrelid) as using_expression,
+    pg_get_expr(pol.polwithcheck, pol.polrelid) as with_check_expression
+FROM pg_policy pol
+JOIN pg_class pc ON pol.polrelid = pc.oid
+WHERE pc.relname = 'items';
+
+-- Test with service role (bypasses RLS) - only use in SQL editor, not in app!
+-- This will show all data regardless of RLS policies
+SELECT 
+    'Total shopping lists' as metric,
+    COUNT(*) as count
+FROM shopping_lists
+UNION ALL
+SELECT 
+    'Total items' as metric,
+    COUNT(*) as count
+FROM items
+UNION ALL
+SELECT 
+    'Lists with items' as metric,
+    COUNT(DISTINCT sl.id) as count
+FROM shopping_lists sl
+JOIN items i ON i.list_id = sl.id;

--- a/create_trigger_final.sql
+++ b/create_trigger_final.sql
@@ -1,0 +1,61 @@
+-- Drop existing trigger and function if they exist
+DROP TRIGGER IF EXISTS update_list_timestamp_on_item_change ON items;
+DROP FUNCTION IF EXISTS update_list_timestamp_on_item_change();
+
+-- Create the function
+CREATE OR REPLACE FUNCTION update_list_timestamp_on_item_change()
+RETURNS TRIGGER AS $$
+BEGIN
+  -- For INSERT and UPDATE, use NEW.list_id
+  IF (TG_OP = 'INSERT' OR TG_OP = 'UPDATE') THEN
+    UPDATE shopping_lists 
+    SET updated_at = NOW() 
+    WHERE id = NEW.list_id;
+    RETURN NEW;
+  -- For DELETE, use OLD.list_id
+  ELSIF (TG_OP = 'DELETE') THEN
+    UPDATE shopping_lists 
+    SET updated_at = NOW() 
+    WHERE id = OLD.list_id;
+    RETURN OLD;
+  END IF;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Create the trigger
+CREATE TRIGGER update_list_timestamp_on_item_change
+  AFTER INSERT OR UPDATE OR DELETE ON items
+  FOR EACH ROW
+  EXECUTE FUNCTION update_list_timestamp_on_item_change();
+
+-- Verify it was created
+SELECT 
+    'Trigger created: ' || tgname as status,
+    tgenabled as is_enabled
+FROM pg_trigger
+WHERE tgname = 'update_list_timestamp_on_item_change';
+
+-- Test it immediately
+WITH test_update AS (
+    SELECT i.id as item_id, i.list_id, sl.updated_at as before_update
+    FROM items i
+    JOIN shopping_lists sl ON sl.id = i.list_id
+    LIMIT 1
+),
+do_update AS (
+    UPDATE items 
+    SET notes = COALESCE(notes, '') || ' [Trigger test: ' || NOW()::time || ']'
+    WHERE id = (SELECT item_id FROM test_update)
+    RETURNING id, list_id
+)
+SELECT 
+    sl.name as list_name,
+    tu.before_update,
+    sl.updated_at as after_update,
+    CASE 
+        WHEN sl.updated_at > tu.before_update THEN '✅ TRIGGER IS NOW WORKING!'
+        ELSE '❌ TRIGGER STILL NOT WORKING'
+    END as result
+FROM shopping_lists sl
+JOIN do_update du ON sl.id = du.list_id
+CROSS JOIN test_update tu;

--- a/debug_recently_viewed.sql
+++ b/debug_recently_viewed.sql
@@ -1,0 +1,64 @@
+-- Check if the trigger exists
+SELECT 
+    tgname as trigger_name,
+    tgrelid::regclass as table_name,
+    proname as function_name
+FROM pg_trigger
+JOIN pg_proc ON pg_proc.oid = pg_trigger.tgfoid
+WHERE tgname = 'update_list_timestamp_on_item_change';
+
+-- Check recent shopping lists ordered by updated_at
+SELECT 
+    id,
+    name,
+    updated_at,
+    created_at,
+    updated_at - created_at as time_since_creation
+FROM shopping_lists
+WHERE user_id = auth.uid()
+ORDER BY updated_at DESC
+LIMIT 10;
+
+-- Test the trigger by updating an item
+-- First, show current state of a list
+SELECT 
+    sl.id as list_id,
+    sl.name as list_name,
+    sl.updated_at as list_updated_at,
+    COUNT(i.id) as item_count
+FROM shopping_lists sl
+LEFT JOIN items i ON i.list_id = sl.id
+WHERE sl.user_id = auth.uid()
+GROUP BY sl.id, sl.name, sl.updated_at
+ORDER BY sl.updated_at DESC
+LIMIT 1;
+
+-- Update an item in the oldest list to test if it moves to the top
+WITH oldest_list AS (
+    SELECT id 
+    FROM shopping_lists 
+    WHERE user_id = auth.uid() 
+    ORDER BY updated_at ASC 
+    LIMIT 1
+),
+first_item AS (
+    SELECT i.id 
+    FROM items i
+    JOIN oldest_list ol ON i.list_id = ol.id
+    LIMIT 1
+)
+UPDATE items 
+SET notes = 'Testing trigger - ' || NOW()::text
+WHERE id = (SELECT id FROM first_item)
+RETURNING id, list_id, notes;
+
+-- Check if the list's updated_at changed
+SELECT 
+    id,
+    name,
+    updated_at,
+    NOW() - updated_at as time_ago
+FROM shopping_lists
+WHERE user_id = auth.uid()
+ORDER BY updated_at DESC
+LIMIT 10;

--- a/diagnose_lists.sql
+++ b/diagnose_lists.sql
@@ -1,0 +1,64 @@
+-- 1. Check if auth.uid() is returning a value
+SELECT auth.uid() as current_user_id;
+
+-- 2. Check all shopping lists (without user filter)
+SELECT 
+    id,
+    user_id,
+    name,
+    updated_at,
+    created_at,
+    (SELECT COUNT(*) FROM items WHERE list_id = shopping_lists.id) as item_count
+FROM shopping_lists
+ORDER BY updated_at DESC
+LIMIT 10;
+
+-- 3. Check if there are any items at all
+SELECT COUNT(*) as total_items FROM items;
+
+-- 4. Check shopping lists for a specific user (replace with your user ID)
+-- You can get your user ID from the Auth section in Supabase dashboard
+/*
+SELECT 
+    sl.id,
+    sl.name,
+    sl.updated_at,
+    sl.created_at,
+    COUNT(i.id) as item_count
+FROM shopping_lists sl
+LEFT JOIN items i ON i.list_id = sl.id
+WHERE sl.user_id = 'YOUR-USER-ID-HERE'
+GROUP BY sl.id, sl.name, sl.updated_at, sl.created_at
+ORDER BY sl.updated_at DESC;
+*/
+
+-- 5. Test query without user filter to see data structure
+SELECT 
+    sl.id as list_id,
+    sl.name as list_name,
+    sl.user_id,
+    sl.updated_at as list_updated,
+    i.id as item_id,
+    i.name as item_name,
+    i.updated_at as item_updated
+FROM shopping_lists sl
+LEFT JOIN items i ON i.list_id = sl.id
+ORDER BY sl.updated_at DESC
+LIMIT 20;
+
+-- 6. Check if the trigger function exists
+SELECT 
+    proname as function_name,
+    prosrc as function_source
+FROM pg_proc
+WHERE proname = 'update_list_timestamp_on_item_change';
+
+-- 7. Check if any lists have been updated recently
+SELECT 
+    id,
+    name,
+    updated_at,
+    NOW() - updated_at as time_since_update
+FROM shopping_lists
+WHERE updated_at > NOW() - INTERVAL '1 hour'
+ORDER BY updated_at DESC;

--- a/manual_trigger_test.sql
+++ b/manual_trigger_test.sql
@@ -1,0 +1,64 @@
+-- Manual trigger test without auth dependency
+
+-- 1. First, let's see some actual data
+SELECT 
+    sl.id as list_id,
+    sl.name as list_name,
+    sl.updated_at as list_before_update,
+    i.id as item_id,
+    i.name as item_name
+FROM shopping_lists sl
+JOIN items i ON i.list_id = sl.id
+LIMIT 5;
+
+-- 2. Pick one item from above results and note its ID and the list's current updated_at
+-- Then run this update (replace with actual item ID):
+/*
+UPDATE items 
+SET name = name || ' - updated at ' || NOW()::time
+WHERE id = 'PASTE-ITEM-ID-HERE'
+RETURNING id, list_id, name, updated_at;
+*/
+
+-- 3. After running the update above, check if the list's updated_at changed:
+-- (replace with the list_id from step 1)
+/*
+SELECT 
+    id,
+    name,
+    updated_at as list_after_update,
+    NOW() - updated_at as seconds_ago
+FROM shopping_lists
+WHERE id = 'PASTE-LIST-ID-HERE';
+*/
+
+-- 4. Alternative: Update the first item found and check results immediately
+WITH item_to_update AS (
+    SELECT i.id as item_id, i.list_id
+    FROM items i
+    JOIN shopping_lists sl ON sl.id = i.list_id
+    LIMIT 1
+),
+list_before AS (
+    SELECT sl.updated_at as before_timestamp
+    FROM shopping_lists sl
+    JOIN item_to_update itu ON sl.id = itu.list_id
+),
+do_update AS (
+    UPDATE items 
+    SET notes = 'Trigger test at ' || NOW()::text
+    WHERE id = (SELECT item_id FROM item_to_update)
+    RETURNING id, list_id
+)
+SELECT 
+    sl.id,
+    sl.name,
+    lb.before_timestamp,
+    sl.updated_at as after_timestamp,
+    CASE 
+        WHEN sl.updated_at > lb.before_timestamp THEN 'TRIGGER WORKED!'
+        ELSE 'TRIGGER DID NOT WORK'
+    END as result
+FROM shopping_lists sl
+JOIN do_update du ON sl.id = du.list_id
+CROSS JOIN list_before lb;

--- a/sql/fix_recently_viewed_trigger.sql
+++ b/sql/fix_recently_viewed_trigger.sql
@@ -1,0 +1,32 @@
+-- Function to update shopping list's updated_at when items are modified
+CREATE OR REPLACE FUNCTION update_list_timestamp_on_item_change()
+RETURNS TRIGGER AS $$
+BEGIN
+  -- For INSERT and UPDATE, use NEW.list_id
+  IF (TG_OP = 'INSERT' OR TG_OP = 'UPDATE') THEN
+    UPDATE shopping_lists 
+    SET updated_at = NOW() 
+    WHERE id = NEW.list_id;
+    RETURN NEW;
+  -- For DELETE, use OLD.list_id
+  ELSIF (TG_OP = 'DELETE') THEN
+    UPDATE shopping_lists 
+    SET updated_at = NOW() 
+    WHERE id = OLD.list_id;
+    RETURN OLD;
+  END IF;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Drop existing trigger if it exists
+DROP TRIGGER IF EXISTS update_list_timestamp_on_item_change ON items;
+
+-- Create trigger for items table
+CREATE TRIGGER update_list_timestamp_on_item_change
+  AFTER INSERT OR UPDATE OR DELETE ON items
+  FOR EACH ROW
+  EXECUTE FUNCTION update_list_timestamp_on_item_change();
+
+-- Add comment explaining the trigger
+COMMENT ON TRIGGER update_list_timestamp_on_item_change ON items IS 
+  'Updates the shopping list updated_at timestamp whenever items in that list are created, updated, or deleted';

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -199,6 +199,14 @@ export default function DashboardPage() {
             completedCount: list.items?.filter((item: any) => item.is_checked)?.length || 0
           }
         })
+        
+        // Sort lists by updated_at in descending order (most recent first)
+        listsWithCounts.sort((a, b) => {
+          const dateA = new Date(a.updated_at).getTime()
+          const dateB = new Date(b.updated_at).getTime()
+          return dateB - dateA
+        })
+        
         setShoppingLists(listsWithCounts)
       }
     } catch (error) {

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -178,6 +178,34 @@ export default function DashboardPage() {
     checkAuth()
   }, [])
 
+  // Refresh lists when the page gains focus (e.g., when navigating back)
+  useEffect(() => {
+    const handleFocus = () => {
+      if (user && !isDemoMode) {
+        console.log('Dashboard: Page gained focus, refreshing lists...')
+        fetchShoppingLists(user.id)
+      }
+    }
+
+    // Listen for focus events
+    window.addEventListener('focus', handleFocus)
+    
+    // Also refresh when the page becomes visible (handles tab switching)
+    const handleVisibilityChange = () => {
+      if (!document.hidden && user && !isDemoMode) {
+        console.log('Dashboard: Page became visible, refreshing lists...')
+        fetchShoppingLists(user.id)
+      }
+    }
+    
+    document.addEventListener('visibilitychange', handleVisibilityChange)
+
+    return () => {
+      window.removeEventListener('focus', handleFocus)
+      document.removeEventListener('visibilitychange', handleVisibilityChange)
+    }
+  }, [user, isDemoMode])
+
   const fetchShoppingLists = async (userId: string) => {
     try {
       const { data, error } = await getShoppingLists(userId)
@@ -200,12 +228,26 @@ export default function DashboardPage() {
           }
         })
         
+        // Debug: Log lists before sorting
+        console.log('Dashboard: Lists before sorting:', listsWithCounts.map(l => ({
+          name: l.name,
+          updated_at: l.updated_at,
+          date: new Date(l.updated_at).toLocaleString()
+        })))
+        
         // Sort lists by updated_at in descending order (most recent first)
         listsWithCounts.sort((a, b) => {
           const dateA = new Date(a.updated_at).getTime()
           const dateB = new Date(b.updated_at).getTime()
           return dateB - dateA
         })
+        
+        // Debug: Log lists after sorting
+        console.log('Dashboard: Lists after sorting:', listsWithCounts.map(l => ({
+          name: l.name,
+          updated_at: l.updated_at,
+          date: new Date(l.updated_at).toLocaleString()
+        })))
         
         setShoppingLists(listsWithCounts)
       }

--- a/src/lib/offline/client.ts
+++ b/src/lib/offline/client.ts
@@ -380,6 +380,12 @@ class OfflineClient {
             ...listRecord.data,
             updated_at: new Date().toISOString()
           }
+          console.log('OfflineClient: Updating list timestamp after createItem (online):', {
+            listId: data.list_id,
+            listName: updatedList.name,
+            oldTimestamp: listRecord.data.updated_at,
+            newTimestamp: updatedList.updated_at
+          })
           await offlineStorage.saveShoppingList(updatedList, 'update', false)
         }
         

--- a/src/lib/supabase/client.ts
+++ b/src/lib/supabase/client.ts
@@ -29,6 +29,11 @@ export const supabase = createSupabaseClient()
 
 // Helper function to update shopping list timestamp
 async function updateListTimestamp(listId: string) {
+  if (!supabase) {
+    console.error('Cannot update list timestamp: Supabase client not available')
+    return
+  }
+  
   try {
     const { error } = await supabase
       .from('shopping_lists')

--- a/src/lib/supabase/client.ts
+++ b/src/lib/supabase/client.ts
@@ -27,6 +27,22 @@ export const createSupabaseClient = () => {
 
 export const supabase = createSupabaseClient()
 
+// Helper function to update shopping list timestamp
+async function updateListTimestamp(listId: string) {
+  try {
+    const { error } = await supabase
+      .from('shopping_lists')
+      .update({ updated_at: new Date().toISOString() })
+      .eq('id', listId)
+    
+    if (error) {
+      console.error('Failed to update list timestamp:', error)
+    }
+  } catch (err) {
+    console.error('Error updating list timestamp:', err)
+  }
+}
+
 // Re-export offline client functions for backward compatibility
 export const getShoppingLists = offlineClient.getShoppingLists
 export const getShoppingList = offlineClient.getShoppingList  
@@ -282,6 +298,11 @@ export async function createItemOriginal(item: NewItem) {
       return { data: null, error: errorMessage }
     }
 
+    // Update the list's timestamp
+    if (data) {
+      await updateListTimestamp(item.list_id)
+    }
+
     return { data, error: null }
 
   } catch (error) {
@@ -340,6 +361,11 @@ export async function updateItemOriginal(itemId: string, updates: UpdateItem) {
       .select()
       .single()
 
+    // Update the list's timestamp
+    if (data && !error) {
+      await updateListTimestamp(itemCheck.list_id)
+    }
+
     return { data, error }
 
   } catch (error) {
@@ -364,12 +390,34 @@ export async function toggleItemCheckedOriginal(itemId: string, isChecked: boole
 export async function deleteItemOriginal(itemId: string) {
   if (!supabase) return { error: 'Supabase not available' }
 
-  const { error } = await supabase
-    .from('items')
-    .delete()
-    .eq('id', itemId)
+  try {
+    // First get the list_id before deleting
+    const { data: item, error: fetchError } = await supabase
+      .from('items')
+      .select('list_id')
+      .eq('id', itemId)
+      .single()
+    
+    if (fetchError || !item) {
+      return { error: fetchError || 'Item not found' }
+    }
 
-  return { error }
+    // Delete the item
+    const { error } = await supabase
+      .from('items')
+      .delete()
+      .eq('id', itemId)
+
+    // Update the list's timestamp if deletion was successful
+    if (!error && item.list_id) {
+      await updateListTimestamp(item.list_id)
+    }
+
+    return { error }
+  } catch (error) {
+    console.error('deleteItem unexpected error:', error)
+    return { error: 'Unexpected error occurred' }
+  }
 }
 
 // =============================================

--- a/test_trigger_simple.sql
+++ b/test_trigger_simple.sql
@@ -1,0 +1,38 @@
+-- 1. First check if trigger exists
+SELECT EXISTS (
+    SELECT 1 
+    FROM pg_trigger 
+    WHERE tgname = 'update_list_timestamp_on_item_change'
+) as trigger_exists;
+
+-- 2. Get a list and its current updated_at
+SELECT 
+    sl.id,
+    sl.name,
+    sl.updated_at as before_update,
+    i.id as item_id,
+    i.name as item_name
+FROM shopping_lists sl
+JOIN items i ON i.list_id = sl.id
+WHERE sl.user_id = auth.uid()
+LIMIT 1;
+
+-- 3. Note the list ID and item ID from above, then run this update
+-- Replace 'YOUR_ITEM_ID' with the actual item ID from step 2
+/*
+UPDATE items 
+SET name = name || ' (updated)'
+WHERE id = 'YOUR_ITEM_ID'
+RETURNING id, name, updated_at;
+*/
+
+-- 4. Check if the list's updated_at changed
+-- Replace 'YOUR_LIST_ID' with the actual list ID from step 2
+/*
+SELECT 
+    id,
+    name,
+    updated_at as after_update
+FROM shopping_lists
+WHERE id = 'YOUR_LIST_ID';
+*/

--- a/test_without_auth.sql
+++ b/test_without_auth.sql
@@ -1,0 +1,80 @@
+-- Working queries for Supabase SQL Editor (without auth context)
+
+-- 1. Find your user ID from the Auth dashboard, or use this query:
+SELECT 
+    id as user_id,
+    email,
+    created_at
+FROM auth.users
+ORDER BY created_at DESC;
+
+-- 2. Once you have your user ID, test the trigger with these queries:
+-- Replace 'YOUR-USER-ID' with your actual user ID from above
+
+-- First, check your shopping lists
+SELECT 
+    id,
+    name,
+    updated_at,
+    created_at
+FROM shopping_lists
+WHERE user_id = 'YOUR-USER-ID'
+ORDER BY updated_at DESC;
+
+-- 3. Test the trigger by updating an item
+-- This will update the first item found in your lists and check if the trigger works
+WITH your_user AS (
+    SELECT 'YOUR-USER-ID'::uuid as user_id  -- REPLACE WITH YOUR USER ID
+),
+item_to_update AS (
+    SELECT i.id as item_id, i.list_id, sl.updated_at as list_updated_before
+    FROM items i
+    JOIN shopping_lists sl ON sl.id = i.list_id
+    JOIN your_user yu ON sl.user_id = yu.user_id
+    LIMIT 1
+),
+do_update AS (
+    UPDATE items 
+    SET notes = 'Trigger test at ' || NOW()::text
+    WHERE id = (SELECT item_id FROM item_to_update)
+    RETURNING id, list_id
+)
+SELECT 
+    sl.id as list_id,
+    sl.name as list_name,
+    itu.list_updated_before as updated_before,
+    sl.updated_at as updated_after,
+    CASE 
+        WHEN sl.updated_at > itu.list_updated_before THEN '✅ TRIGGER IS WORKING!'
+        ELSE '❌ TRIGGER NOT WORKING'
+    END as trigger_status,
+    sl.updated_at - itu.list_updated_before as time_difference
+FROM shopping_lists sl
+JOIN do_update du ON sl.id = du.list_id
+JOIN item_to_update itu ON itu.list_id = sl.id;
+
+-- 4. Alternative: Simple test without CTE
+-- First run this to see your data:
+/*
+SELECT 
+    sl.id as list_id,
+    sl.name,
+    sl.updated_at,
+    i.id as item_id,
+    i.name as item_name
+FROM shopping_lists sl
+JOIN items i ON i.list_id = sl.id
+WHERE sl.user_id = 'YOUR-USER-ID'
+LIMIT 5;
+*/
+
+-- Then update one item and check the list's timestamp:
+/*
+UPDATE items 
+SET name = name || ' (test)'
+WHERE id = 'ITEM-ID-FROM-ABOVE'
+RETURNING *;
+
+-- Then immediately check:
+SELECT * FROM shopping_lists WHERE id = 'LIST-ID-FROM-ABOVE';
+*/

--- a/verify_trigger_setup.sql
+++ b/verify_trigger_setup.sql
@@ -1,0 +1,60 @@
+-- Comprehensive trigger verification
+
+-- 1. Check if the trigger exists
+SELECT 
+    tgname as trigger_name,
+    tgrelid::regclass as table_name,
+    tgtype as trigger_type,
+    tgenabled as is_enabled,
+    proname as function_name
+FROM pg_trigger
+JOIN pg_proc ON pg_proc.oid = pg_trigger.tgfoid
+WHERE tgname = 'update_list_timestamp_on_item_change';
+
+-- 2. If no results above, check all triggers on items table
+SELECT 
+    tgname as trigger_name,
+    tgtype as trigger_type,
+    tgenabled as is_enabled,
+    proname as function_name
+FROM pg_trigger
+JOIN pg_proc ON pg_proc.oid = pg_trigger.tgfoid
+WHERE tgrelid = 'items'::regclass
+AND tgisinternal = false;
+
+-- 3. Check if the function exists
+SELECT 
+    proname as function_name,
+    pronargs as arg_count,
+    prorettype::regtype as return_type
+FROM pg_proc
+WHERE proname = 'update_list_timestamp_on_item_change';
+
+-- 4. If the trigger doesn't exist, here's the SQL to create it again:
+/*
+-- Function to update shopping list's updated_at when items are modified
+CREATE OR REPLACE FUNCTION update_list_timestamp_on_item_change()
+RETURNS TRIGGER AS $$
+BEGIN
+  -- For INSERT and UPDATE, use NEW.list_id
+  IF (TG_OP = 'INSERT' OR TG_OP = 'UPDATE') THEN
+    UPDATE shopping_lists 
+    SET updated_at = NOW() 
+    WHERE id = NEW.list_id;
+    RETURN NEW;
+  -- For DELETE, use OLD.list_id
+  ELSIF (TG_OP = 'DELETE') THEN
+    UPDATE shopping_lists 
+    SET updated_at = NOW() 
+    WHERE id = OLD.list_id;
+    RETURN OLD;
+  END IF;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Create trigger for items table
+CREATE TRIGGER update_list_timestamp_on_item_change
+  AFTER INSERT OR UPDATE OR DELETE ON items
+  FOR EACH ROW
+  EXECUTE FUNCTION update_list_timestamp_on_item_change();
+*/


### PR DESCRIPTION
Fixes the recently viewed list mechanism by ensuring correct sorting and updating list timestamps on item changes.

The "recently viewed" logic was flawed because lists weren't sorted consistently in the UI and offline mode, and crucially, a list's `updated_at` timestamp wasn't updated when its items were added, modified, or deleted. This meant lists with active item changes wouldn't appear as recently used. This PR addresses these issues by adding sorting and implementing a database trigger and offline client logic to update the list's timestamp on item activity.

---
<a href="https://cursor.com/background-agent?bcId=bc-a68dd5f6-ef78-43a0-be24-45327dc9fb10">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a68dd5f6-ef78-43a0-be24-45327dc9fb10">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>