### PR TITLE
Fix blurred shopping list title

### DIFF
--- a/src/app/list/[listId]/page.tsx
+++ b/src/app/list/[listId]/page.tsx
@@ -1422,7 +1422,7 @@ export default function ListPage() {
               <ArrowLeft className="w-5 h-5" />
             </Link>
             <div className="flex-1">
-              <h1 className="text-2xl font-bold animate-scale-in bg-gradient-to-r from-primary to-secondary bg-clip-text text-transparent" style={{ textShadow: 'none' }}>{list.name}</h1>
+              <h1 className="text-2xl font-bold text-glass-heading animate-scale-in bg-gradient-to-r from-primary to-secondary bg-clip-text text-transparent" style={{ textShadow: 'none' }}>{list.name}</h1>
               {list.description && (
                 <p className="text-glass-muted animate-slide-up stagger-1">{list.description}</p>
               )}

--- a/src/app/list/[listId]/page.tsx
+++ b/src/app/list/[listId]/page.tsx
@@ -1422,7 +1422,7 @@ export default function ListPage() {
               <ArrowLeft className="w-5 h-5" />
             </Link>
             <div className="flex-1">
-              <h1 className="text-2xl font-bold text-glass-heading animate-scale-in bg-gradient-to-r from-primary to-secondary bg-clip-text text-transparent" style={{ textShadow: 'none' }}>{list.name}</h1>
+              <h1 className="text-2xl font-bold text-glass-heading animate-scale-in" style={{ textShadow: 'none' }}>{list.name}</h1>
               {list.description && (
                 <p className="text-glass-muted animate-slide-up stagger-1">{list.description}</p>
               )}

--- a/src/app/list/[listId]/page.tsx
+++ b/src/app/list/[listId]/page.tsx
@@ -1422,7 +1422,7 @@ export default function ListPage() {
               <ArrowLeft className="w-5 h-5" />
             </Link>
             <div className="flex-1">
-              <h1 className="text-2xl font-bold text-glass-heading animate-scale-in bg-gradient-to-r from-primary to-secondary bg-clip-text text-transparent">{list.name}</h1>
+              <h1 className="text-2xl font-bold animate-scale-in bg-gradient-to-r from-primary to-secondary bg-clip-text text-transparent" style={{ textShadow: 'none' }}>{list.name}</h1>
               {list.description && (
                 <p className="text-glass-muted animate-slide-up stagger-1">{list.description}</p>
               )}


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Fix blurred shopping list title by removing conflicting `text-shadow` when gradient text is applied.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->

---
<a href="https://cursor.com/background-agent?bcId=bc-8a7f7cb9-f50d-437e-86ce-3931df6e8449">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-8a7f7cb9-f50d-437e-86ce-3931df6e8449">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>